### PR TITLE
Converted to a class

### DIFF
--- a/dark-admin.php
+++ b/dark-admin.php
@@ -12,170 +12,130 @@ License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */
 
+class DarkAdmin {
+	function __construct() {
+		if ( ! defined( 'DARKADMIN' ) ) {
+			define( 'DARKADMIN', true );
+		}
+		remove_action( 'admin_init', 'register_admin_color_schemes', 1 );
+		add_action( 'admin_init', array( $this, 'register_admin_color_scheme' ) );
+		add_action( 'login_init', array( $this, 'replace_wp_default_styles' ) );
+		add_action( 'login_init', array( $this, 'fix_login_color_scheme' ) );
+		add_action( 'init', array( $this, 'replace_admin_bar_style' ) );
+		add_action( 'admin_init', array( $this, 'replace_wp_default_styles' ) );
+		add_filter( 'tiny_mce_before_init', array( $this, 'mce_init' ) );
 
-if ( ! defined( 'darkAdmin' ) )
-	define( 'darkAdmin', true );
+		add_filter( 'style_loader_tag', array( $this, 'fix_style_tag_href' ) );
+		add_filter( 'get_user_option_admin_color', array( $this, 'force_admin_color' ) );
+		add_filter( 'body_class', array( $this, 'add_body_class_frontend' ) );
+		add_filter( 'admin_body_class', array( $this, 'add_body_class_backend' ) );
 
-
-// register Open Sans stylesheet
-add_action( 'init', 'darkAdmin_register_open_sans' );
-function darkAdmin_register_open_sans() {
-	wp_register_style(
-		'open-sans',
-		'//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600&subset=latin-ext,latin',
-		plugins_url( 'css/opensans.css', __FILE__ ),
-		false,
-		'20130605'
-	);
-}
-
-// register Dark Admin admin color scheme
-function darkAdmin_register_admin_color_scheme() {
-
-	global $wp_styles, $_wp_admin_css_colors;
-	wp_admin_css_color(
-		'darkadmin',
-		__( 'DarkAdmin' ),
-		plugins_url( 'css/colors-darkadmin.css', __FILE__ ),
-		array( '#222', '#333', '#0074a2', '#2ea2cc' )
-	);
-	$_wp_admin_css_colors[ 'darkadmin' ]->icon_colors = array( 'base' => '#999', 'focus' => '#2ea2cc', 'current' => '#fff' );
-
-	// set modification time
-	$wp_styles->registered[ 'colors' ]->ver = filemtime( plugin_dir_path( __FILE__ ) . 'css/colors-darkadmin.css' );
-
-	// set dependencies
-	$wp_styles->registered[ 'colors' ]->deps[] = 'open-sans';
-	$wp_styles->registered[ 'colors' ]->deps[] = 'dashicons';
-
-}
-remove_action( 'admin_init', 'register_admin_color_schemes', 1);
-add_action( 'admin_init', 'darkAdmin_register_admin_color_scheme' );
-
-// remove WP's default color schemes
-// load Dark Admin css on login screen
-add_action( 'login_init', 'darkAdmin_replace_wp_default_styles' );
-add_action( 'login_init', 'darkAdmin_fix_login_color_scheme' );
-function darkAdmin_fix_login_color_scheme() {
-
-	global $wp_styles;
-
-	$wp_styles->registered[ 'colors-fresh' ]->src = plugins_url( 'css/colors-darkadmin.css', __FILE__ );
-	$wp_styles->registered[ 'colors-fresh' ]->ver = filemtime( plugin_dir_path( __FILE__ ) . 'css/colors-darkadmin.css' );
-	$wp_styles->registered[ 'colors-fresh' ]->deps[] = 'open-sans';
-	$wp_styles->registered[ 'colors-fresh' ]->deps[] = 'dashicons';
-
-}
-
-// replace default `admin-bar.css` with Dark Admin's
-add_action( 'init', 'darkAdmin_replace_admin_bar_style' );
-function darkAdmin_replace_admin_bar_style() {
-
-	global $wp_styles;
-
-	if ( ! isset( $wp_styles->registered[ 'admin-bar' ] ) )
-		return;
-
-	$wp_styles->registered[ 'admin-bar' ]->src = plugins_url( 'css/dark-admin.css', __FILE__ );
-	$wp_styles->registered[ 'admin-bar' ]->ver = filemtime( plugin_dir_path( __FILE__ ) . 'css/dark-admin.css' );
-	$wp_styles->registered[ 'admin-bar' ]->deps[] = 'open-sans';
-	$wp_styles->registered[ 'admin-bar' ]->deps[] = 'dashicons';
-	$wp_styles->registered[ 'admin-bar' ]->extra[ 'suffix' ] = '';
-
-}
-
-// replace some default css files with ours
-add_action( 'admin_init', 'darkAdmin_replace_wp_default_styles' );
-function darkAdmin_replace_wp_default_styles() {
-
-	global $wp_styles;
-	$wp_styles->registered[ 'buttons' ]->src = plugins_url( 'css/buttons.css', __FILE__ );
-	$wp_styles->registered[ 'buttons' ]->ver = filemtime( plugin_dir_path( __FILE__ ) . 'css/buttons.css' );
-	$wp_styles->registered[ 'editor-buttons' ]->src = plugins_url( 'css/editor.css', __FILE__ );
-	$wp_styles->registered[ 'editor-buttons' ]->ver = filemtime( plugin_dir_path( __FILE__ ) . 'css/editor.css' );
-	$wp_styles->registered[ 'media' ]->src = plugins_url( 'css/media.css', __FILE__ );
-	$wp_styles->registered[ 'media' ]->ver = filemtime( plugin_dir_path( __FILE__ ) . 'css/media.css' );
-	$wp_styles->registered[ 'media-views' ]->src = plugins_url( 'css/media-views.css', __FILE__ );
-	$wp_styles->registered[ 'media-views' ]->ver = filemtime( plugin_dir_path( __FILE__ ) . 'css/media-views.css' );
-	$wp_styles->registered[ 'media-views' ]->extra[ 'suffix' ] = '';
-	$wp_styles->registered[ 'wp-admin' ]->src = plugins_url( 'css/dark-admin.css', __FILE__ );
-	$wp_styles->registered[ 'wp-admin' ]->ver = filemtime( plugin_dir_path( __FILE__ ) . 'css/dark-admin.css' );
-	$wp_styles->registered[ 'wp-admin' ]->deps[] = 'open-sans';
-	$wp_styles->registered[ 'wp-admin' ]->deps[] = 'dashicons';
-	$wp_styles->registered[ 'wp-admin' ]->extra[ 'suffix' ] = '';
-	$wp_styles->registered[ 'wp-pointer' ]->src = plugins_url( 'css/wp-pointer.css', __FILE__ );
-	$wp_styles->registered[ 'wp-pointer' ]->ver = filemtime( plugin_dir_path( __FILE__ ) . 'css/wp-pointer.css' );
-
-}
-
-// load Dark Admin's `dialog.css`
-add_filter( 'tiny_mce_before_init', 'darkAdmin_mce_init' );
-function darkAdmin_mce_init( $mce_init ) {
-
-	// make sure we don't override other custom `content_css` files
-	$content_css = plugins_url( 'css/tinymce-content.css', __FILE__ );
-	if ( isset( $mce_init[ 'content_css' ] ) )
-		$content_css .= ',' . $mce_init[ 'content_css' ];
-
-	$mce_init[ 'content_css' ] = $content_css;
-	$mce_init[ 'popup_css' ] = plugins_url( 'css/tinymce-dialog.css', __FILE__ );
-
-	return $mce_init;
-
-}
-
-// load Dark Admin's `wp-admin.css` if it's force printed
-add_filter( 'style_loader_tag', 'darkAdmin_fix_style_tag_href' );
-function darkAdmin_fix_style_tag_href( $handle ) {
-
-	// fix force print in `wp-mce-help.php`
-	if ( strpos( $handle, admin_url( '/css/wp-admin.css' ) ) !== false ) {
-		$handle = str_replace( admin_url( '/css/wp-admin.css' ), plugins_url( 'css/wp-admin.css', __FILE__ ), $handle );
+		add_action( 'wp_head', array( $this, 'override_toolbar_margin' ), 11 );
 	}
 
-	return $handle;
+	public function register_admin_color_scheme() {
+		global $wp_styles, $_wp_admin_css_colors;
+		wp_admin_css_color(
+			'darkadmin',
+			__( 'DarkAdmin' ),
+			plugins_url( 'css/colors-mp6.css', __FILE__ ),
+			array( '#222', '#333', '#0074a2', '#2ea2cc' )
+		);
+		$_wp_admin_css_colors['darkadmin']->icon_colors = array( 'base' => '#999', 'focus' => '#2ea2cc', 'current' => '#fff' );
+		// set modification time
+		$wp_styles->registered['colors']->ver    = filemtime( plugin_dir_path( __FILE__ ) . 'css/colors-mp6.css' );
+		// set dependencies
+		$wp_styles->registered['colors']->deps[] = 'open-sans';
+		$wp_styles->registered['colors']->deps[] = 'dashicons';
+	}
 
-}
+	public function fix_login_color_scheme() {
+		global $wp_styles;
+		$wp_styles->registered['colors-fresh']->src    = plugins_url( 'css/colors-mp6.css', __FILE__ );
+		$wp_styles->registered['colors-fresh']->ver    = filemtime( plugin_dir_path( __FILE__ ) . 'css/colors-mp6.css' );
+		$wp_styles->registered['colors-fresh']->deps[] = 'open-sans';
+		$wp_styles->registered['colors-fresh']->deps[] = 'dashicons';
+	}
 
-add_filter( 'get_user_option_admin_color', 'darkAdmin_force_admin_color' );
-function darkAdmin_force_admin_color( $color_scheme ) {
+	public function replace_wp_default_styles() {
+		global $wp_styles;
+		$wp_styles->registered['buttons']->src                 = plugins_url( 'css/buttons.css', __FILE__ );
+		$wp_styles->registered['buttons']->ver                 = filemtime( plugin_dir_path( __FILE__ ) . 'css/buttons.css' );
+		$wp_styles->registered['editor-buttons']->src          = plugins_url( 'css/editor.css', __FILE__ );
+		$wp_styles->registered['editor-buttons']->ver          = filemtime( plugin_dir_path( __FILE__ ) . 'css/editor.css' );
+		$wp_styles->registered['media']->src                   = plugins_url( 'css/media.css', __FILE__ );
+		$wp_styles->registered['media']->ver                   = filemtime( plugin_dir_path( __FILE__ ) . 'css/media.css' );
+		$wp_styles->registered['media-views']->src             = plugins_url( 'css/media-views.css', __FILE__ );
+		$wp_styles->registered['media-views']->ver             = filemtime( plugin_dir_path( __FILE__ ) . 'css/media-views.css' );
+		$wp_styles->registered['media-views']->extra['suffix'] = '';
+		$wp_styles->registered['wp-admin']->src                = plugins_url( 'css/dark-admin.css', __FILE__ );
+		$wp_styles->registered['wp-admin']->ver                = filemtime( plugin_dir_path( __FILE__ ) . 'css/dark-admin.css' );
+		$wp_styles->registered['wp-admin']->deps[]             = 'open-sans';
+		$wp_styles->registered['wp-admin']->deps[]             = 'dashicons';
+		$wp_styles->registered['wp-admin']->extra['suffix']    = '';
+		$wp_styles->registered['wp-pointer']->src              = plugins_url( 'css/wp-pointer.css', __FILE__ );
+		$wp_styles->registered['wp-pointer']->ver              = filemtime( plugin_dir_path( __FILE__ ) . 'css/wp-pointer.css' );
+	}
 
-        global $_wp_admin_css_colors;
+	public function replace_admin_bar_style() {
+		global $wp_styles;
+		if ( ! isset( $wp_styles->registered['admin-bar'] ) ) {
+			return;
+		}
+		$wp_styles->registered['admin-bar']->src             = plugins_url( 'css/dark-admin.css', __FILE__ );
+		$wp_styles->registered['admin-bar']->ver             = filemtime( plugin_dir_path( __FILE__ ) . 'css/dark-admin.css' );
+		$wp_styles->registered['admin-bar']->deps[]          = 'open-sans';
+		$wp_styles->registered['admin-bar']->deps[]          = 'dashicons';
+		$wp_styles->registered['admin-bar']->extra['suffix'] = '';
+	}
 
-        // if setting is `fresh`, `classic` or doesn't exist, change it to `darkadmin`
-        if ( ! isset( $_wp_admin_css_colors[ $color_scheme ] ) ) {
-                $color_scheme = 'darkadmin';
-        }
+	public function mce_init( $mce_init ) {
+		// make sure we don't override other custom `content_css` files
+		$content_css = plugins_url( 'css/tinymce-content.css', __FILE__ );
+		if ( isset( $mce_init['content_css'] ) ) {
+			$content_css .= ',' . $mce_init['content_css'];
+		}
 
-        return $color_scheme;
+		$mce_init['content_css'] = $content_css;
+		$mce_init['popup_css'] = plugins_url( 'css/tinymce-dialog.css', __FILE__ );
 
-}
+		return $mce_init;
+	}
 
-// Add an `dark-admin` body class to the front-end
-add_filter( 'body_class', 'darkAdmin_add_body_class_frontend' );
-function darkAdmin_add_body_class_frontend( $classes ) {
-	$classes[] = 'dark-admin';
-	return $classes;
-}
+	public function fix_style_tag_href( $handle ) {
+		if ( strpos( $handle, admin_url( '/css/wp-admin.css' ) ) !== false ) {
+			$handle = str_replace( admin_url( '/css/wp-admin.css' ), plugins_url( 'css/wp-admin.css', __FILE__ ), $handle );
+		}
+		return $handle;
+	}
 
-// Add body classes to the back-end
-add_filter( 'admin_body_class', 'darkAdmin_add_body_class_backend' );
-function darkAdmin_add_body_class_backend( $classes ) {
+	public function force_admin_color( $color_scheme ) {
+		global $_wp_admin_css_colors;
+		// if setting is `fresh`, `classic` or doesn't exist, change it to `mp6`
+		if ( ! isset( $_wp_admin_css_colors[ $color_scheme ] ) ) {
+				$color_scheme = 'darkadmin';
+		}
+		return $color_scheme;
+	}
 
-	if ( is_multisite() )
-		$classes .= ' multisite';
+	public function add_body_class_frontend( $classes ) {
+		$classes[] = 'dark-admin';
+		return $classes;
+	}
 
-	if ( is_network_admin() )
-		$classes .= ' network-admin';
+	public function add_body_class_backend( $classes ) {
+		if ( is_multisite() ) {
+			$classes .= ' multisite';
+		}
+		if ( is_network_admin() ) {
+			$classes .= ' network-admin';
+		}
+		return $classes . ' dark-admin no-svg ';
+	}
 
-	return $classes . ' dark-admin no-svg ';
-
-}
-
-// override WP's default toolbar top margin
-add_action( 'wp_head', 'dark-admin_override_toolbar_margin', 11 );
-function darkAdmin_override_toolbar_margin() {
-	if ( is_admin_bar_showing() ) : ?>
+	public function override_toolbar_margin() {
+		if ( is_admin_bar_showing() ) {
+			echo <<<HTML
 <style type="text/css" media="screen">
 	html { margin-top: 32px !important; }
 	* html body { margin-top: 32px !important; }
@@ -184,5 +144,10 @@ function darkAdmin_override_toolbar_margin() {
 		* html body { margin-top: 46px !important; }
 	}
 </style>
-<?php endif;
+HTML;
+		}
+	}
+
 }
+
+new DarkAdmin();


### PR DESCRIPTION
Converted the plugin to a class.
Simplified the code by creating a helper function for replacing the
enqueued CSS files.
Removed the open sans registration.
